### PR TITLE
Docs(sklearn learners wrappers, measures, resampling): standardize docstrings; Fix MeasureSpatialAUC indexing

### DIFF
--- a/mlpy/learners/sklearn/__init__.py
+++ b/mlpy/learners/sklearn/__init__.py
@@ -10,6 +10,8 @@ from .classification import (
     LearnerDecisionTree,
     LearnerRandomForest,
     LearnerGradientBoosting,
+    LearnerAdaBoost,
+    LearnerExtraTrees,
     LearnerSVM,
     LearnerKNN,
     LearnerNaiveBayes,
@@ -23,6 +25,8 @@ from .regression import (
     LearnerDecisionTreeRegressor,
     LearnerRandomForestRegressor,
     LearnerGradientBoostingRegressor,
+    LearnerAdaBoostRegressor,
+    LearnerExtraTreesRegressor,
     LearnerSVR,
     LearnerKNNRegressor,
     LearnerMLPRegressor
@@ -32,6 +36,8 @@ from .auto_wrap import auto_sklearn
 # Aliases for compatibility with registry naming
 LearnerRandomForestClassifier = LearnerRandomForest
 LearnerGradientBoostingClassifier = LearnerGradientBoosting
+LearnerAdaBoostClassifier = LearnerAdaBoost
+LearnerExtraTreesClassifier = LearnerExtraTrees
 LearnerSVMClassifier = LearnerSVM
 LearnerKNNClassifier = LearnerKNN
 LearnerDecisionTreeClassifier = LearnerDecisionTree
@@ -45,6 +51,8 @@ __all__ = [
     "LearnerDecisionTree",
     "LearnerRandomForest",
     "LearnerGradientBoosting",
+    "LearnerAdaBoost",
+    "LearnerExtraTrees",
     "LearnerSVM",
     "LearnerKNN",
     "LearnerNaiveBayes",
@@ -58,6 +66,8 @@ __all__ = [
     "LearnerDecisionTreeRegressor",
     "LearnerRandomForestRegressor",
     "LearnerGradientBoostingRegressor",
+    "LearnerAdaBoostRegressor",
+    "LearnerExtraTreesRegressor",
     "LearnerSVR",
     "LearnerKNNRegressor",
     "LearnerMLPRegressor",
@@ -68,6 +78,8 @@ __all__ = [
     # Aliases for compatibility
     "LearnerRandomForestClassifier",
     "LearnerGradientBoostingClassifier",
+    "LearnerAdaBoostClassifier",
+    "LearnerExtraTreesClassifier",
     "LearnerSVMClassifier",
     "LearnerKNNClassifier",
     "LearnerDecisionTreeClassifier"

--- a/mlpy/learners/sklearn/classification.py
+++ b/mlpy/learners/sklearn/classification.py
@@ -8,7 +8,7 @@ from .base import LearnerClassifSKLearn
 try:
     from sklearn.linear_model import LogisticRegression
     from sklearn.tree import DecisionTreeClassifier
-    from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier
+    from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier, AdaBoostClassifier, ExtraTreesClassifier
     from sklearn.svm import SVC
     from sklearn.neighbors import KNeighborsClassifier
     from sklearn.naive_bayes import GaussianNB
@@ -229,6 +229,113 @@ class LearnerGradientBoosting(LearnerClassifSKLearn):
             **kwargs
         )
 
+class LearnerAdaBoost(LearnerClassifSKLearn):
+    """ AdaBoost classifier wrapper
+
+    Parameters
+    ----------
+    id : str, optional
+        Unique identifier.
+    predict_type : str, optional
+        Type of prediction ("response" or "prob").
+    estimator : object, optional
+        Base estimator to boost.
+    n_estimators : int, optional
+        Maximum number of estimators.
+    learning_rate : float, optional
+        Weighting applied to each classifier.
+    random_state : int, optional
+        Random seed for reproducibility.
+    **kwargs
+        Additional parameters for AdaBoostClassifier
+    """
+
+    def __init__(
+      self,
+      id: Optional[str] = None,
+      predict_type: str = "response",
+      estimator: Optional[object] = None,
+      n_estimators: int = 50,
+      learning_rate: float = 1.0,
+      random_state: Optional[int] = None,
+      **kwargs
+    ):
+        if not _HAS_SKLEARN:
+            raise ImportError("scikit-learn is required for this learner")
+
+        super().__init__(
+            estimator_class=AdaBoostClassifier,
+            id=id or "adaboost",
+            predict_type=predict_type,
+            estimator=estimator,
+            n_estimators=n_estimators,
+            learning_rate=learning_rate,
+            random_state=random_state,
+            **kwargs
+        )
+
+class LearnerExtraTrees(LearnerClassifSKLearn):
+    """ Extra Trees classifier wrapper
+
+    Parameters
+    ----------
+
+    id : str, optional
+        Unique identifier.
+    predict_type : str, optional
+        Type of prediction ("response" or "prob").
+    n_estimators : int, optional
+        Number of trees.
+    criterion : str, optional
+        Function to measure split quality.
+    max_depth : int, optional
+        Maximum depth of trees.
+    min_samples_split : int, optional
+        Minimum samples required to split.
+    min_samples_leaf : int, optional
+        Minimum samples required at leaf.
+    max_features : str or float, optional
+        Number of features to consider when looking for the best split. Use
+        'sqrt', 'log2', an int, or a float in (0, 1].
+    random_state : int, optional
+        Random seed.
+    n_jobs : int, optional
+        Number of parallel jobs to run for both fit and predict.
+    **kwargs
+        Additional parameters for ExtraTreesClassifier.
+    """
+
+    def __init__(
+        self,
+        id: Optional[str] = None,
+        predict_type: str = "response",
+        n_estimators: int = 100,
+        criterion: str = 'gini',
+        max_depth: Optional[int] = None,
+        min_samples_split: int = 2,
+        min_samples_leaf: int = 1,
+        max_features: str = 'sqrt',
+        random_state: Optional[int] = None,
+        n_jobs: Optional[int] = None,
+        **kwargs
+    ):
+        if not _HAS_SKLEARN:
+            raise ImportError("scikit-learn is required for this learner")
+
+        super().__init__(
+            estimator_class=ExtraTreesClassifier,
+            id=id or "extra_trees",
+            predict_type=predict_type,
+            n_estimators=n_estimators,
+            criterion=criterion,
+            max_depth=max_depth,
+            min_samples_split=min_samples_split,
+            min_samples_leaf=min_samples_leaf,
+            max_features=max_features,
+            random_state=random_state,
+            n_jobs=n_jobs,
+            **kwargs
+        )
 
 class LearnerSVM(LearnerClassifSKLearn):
     """Support Vector Machine classifier wrapper.

--- a/mlpy/learners/sklearn/classification.py
+++ b/mlpy/learners/sklearn/classification.py
@@ -20,25 +20,56 @@ except ImportError:
 
 class LearnerLogisticRegression(LearnerClassifSKLearn):
     """Logistic Regression classifier wrapper.
-    
+
+    Wraps sklearn's LogisticRegression with MLPY's unified interface.
+    Logistic Regression is a linear model for classification that predicts probabilities 
+    using the sigmoid function. Suitable for binary and multiclass classification tasks.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    predict_type : str, optional
-        Type of prediction ("response" or "prob").
-    penalty : str, optional
-        Penalty norm ('l1', 'l2', 'elasticnet', 'none').
-    C : float, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    predict_type : {"response", "prob"}, default="response"
+        Type of prediction to produce.
+    penalty : {"l1", "l2", "elasticnet", "none"}, default="l2"
+        Norm used in the penalization.
+    C : float, default=1.0
         Inverse of regularization strength.
-    solver : str, optional
-        Algorithm to use in optimization.
-    max_iter : int, optional
-        Maximum number of iterations.
-    random_state : int, optional
-        Random seed.
+    solver : {"lbfgs", "liblinear", "saga", ...}, default="lbfgs"
+        Optimization algorithm.
+    max_iter : int, default=100
+        Maximum number of iterations taken for the solvers to converge.
+    random_state : int, default=None
+        Random seed for reproducibility.
     **kwargs
-        Additional parameters for LogisticRegression.
+        Additional estimator parameters forwarded to
+        ``sklearn.linear_model.LogisticRegression``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskClassif
+    >>> from mlpy.learners.sklearn import LearnerLogisticRegression
+    >>> from sklearn.datasets import load_iris
+    >>> iris = load_iris()
+    >>> df = pd.DataFrame(iris.data, columns=iris.feature_names)
+    >>> df['target'] = iris.target
+    >>> task = TaskClassif(data=df, target='target')
+    >>> learner = LearnerLogisticRegression(max_iter=200)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> pred.response.shape[0] == len(df)
+    True
+
+    Notes
+    -----
+    This is a wrapper around ``sklearn.linear_model.LogisticRegression``.
+    For more details, see the sklearn documentation.
+
+    See Also
+    --------
+    LearnerSVM : Support Vector Machine classifier
+    LearnerDecisionTree : Decision tree classifier
     """
     
     def __init__(
@@ -70,25 +101,62 @@ class LearnerLogisticRegression(LearnerClassifSKLearn):
 
 class LearnerDecisionTree(LearnerClassifSKLearn):
     """Decision Tree classifier wrapper.
-    
+
+    Wraps sklearn's DecisionTreeClassifier with MLPY's unified interface.
+    Decision Trees recursively partition the feature space with axis-aligned splits
+    to learn simple rules. Suitable for non-linear relationships, mixed feature
+    types, and interpretable models.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    predict_type : str, optional
-        Type of prediction ("response" or "prob").
-    criterion : str, optional
-        Function to measure split quality.
-    max_depth : int, optional
-        Maximum depth of tree.
-    min_samples_split : int, optional
-        Minimum samples required to split.
-    min_samples_leaf : int, optional
-        Minimum samples required at leaf.
-    random_state : int, optional
-        Random seed.
+    id : str, default=None
+        Unique identifier for the learner.
+    predict_type : {"response", "prob"}, default="response"
+        Type of prediction to produce.
+    criterion : {"gini", "entropy", "log_loss"}, default="gini"
+        Function to measure the quality of a split.
+    max_depth : int or None, default=None
+        Maximum depth of the tree.
+    min_samples_split : int, default=2
+        Minimum number of samples required to split an internal node.
+    min_samples_leaf : int, default=1
+        Minimum number of samples required to be at a leaf node.
+    random_state : int, default=None
+        Random seed for reproducibility.
     **kwargs
-        Additional parameters for DecisionTreeClassifier.
+        Additional estimator parameters forwarded to
+        ``sklearn.tree.DecisionTreeClassifier``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskClassif
+    >>> from mlpy.learners.sklearn import LearnerDecisionTree
+    >>> from sklearn.datasets import load_iris
+    >>> iris = load_iris()
+    >>> df = pd.DataFrame(iris.data, columns=iris.feature_names)
+    >>> df['target'] = iris.target
+    >>> task = TaskClassif(data=df, target='target')
+    >>> learner = LearnerDecisionTree(max_depth=3)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> len(pred.response) == len(df)
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.tree.DecisionTreeClassifier``.
+    For more details, see the sklearn documentation.
+
+    References
+    ----------
+    .. [1] Breiman, Friedman, Olshen, and Stone (1984).
+           Classification and Regression Trees. Wadsworth.
+
+    See Also
+    --------
+    LearnerRandomForest : Random forest classifier
+    LearnerExtraTrees : Extremely randomized trees classifier
     """
     
     def __init__(
@@ -120,31 +188,68 @@ class LearnerDecisionTree(LearnerClassifSKLearn):
 
 class LearnerRandomForest(LearnerClassifSKLearn):
     """Random Forest classifier wrapper.
-    
+
+    Wraps sklearn's RandomForestClassifier with MLPY's unified interface.
+    Random Forests build an ensemble of decision trees on bootstrapped samples
+    with feature randomness and aggregate their votes. Suitable for robust
+    performance with minimal tuning and for estimating feature importance.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    predict_type : str, optional
-        Type of prediction ("response" or "prob").
-    n_estimators : int, optional
-        Number of trees.
-    criterion : str, optional
-        Function to measure split quality.
-    max_depth : int, optional
-        Maximum depth of trees.
-    min_samples_split : int, optional
-        Minimum samples required to split.
-    min_samples_leaf : int, optional
-        Minimum samples required at leaf.
-    max_features : str or float, optional
-        Number of features to consider for best split.
-    random_state : int, optional
-        Random seed.
-    n_jobs : int, optional
-        Number of parallel jobs.
+    id : str, default=None
+        Unique identifier for the learner.
+    predict_type : {"response", "prob"}, default="response"
+        Type of prediction to produce.
+    n_estimators : int, default=100
+        Number of trees in the forest.
+    criterion : {"gini", "entropy", "log_loss"}, default="gini"
+        Function to measure the quality of a split.
+    max_depth : int or None, default=None
+        Maximum depth of the trees.
+    min_samples_split : int, default=2
+        Minimum number of samples required to split an internal node.
+    min_samples_leaf : int, default=1
+        Minimum number of samples required to be at a leaf node.
+    max_features : {"sqrt", "log2"} or float, default="sqrt"
+        Number of features to consider when looking for the best split.
+    random_state : int, default=None
+        Random seed for reproducibility.
+    n_jobs : int, default=None
+        Number of parallel jobs to run.
     **kwargs
-        Additional parameters for RandomForestClassifier.
+        Additional estimator parameters forwarded to
+        ``sklearn.ensemble.RandomForestClassifier``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskClassif
+    >>> from mlpy.learners.sklearn import LearnerRandomForest
+    >>> from sklearn.datasets import load_iris
+    >>> iris = load_iris()
+    >>> df = pd.DataFrame(iris.data, columns=iris.feature_names)
+    >>> df['target'] = iris.target
+    >>> task = TaskClassif(data=df, target='target')
+    >>> learner = LearnerRandomForest(n_estimators=200, random_state=0)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> hasattr(pred, "prob")
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.ensemble.RandomForestClassifier``.
+    For more details, see the sklearn documentation.
+
+    References
+    ----------
+    .. [1] Breiman, L. (2001). Random Forests. Machine Learning, 45(1), 5–32.
+
+    See Also
+    --------
+    LearnerDecisionTree : Single decision tree classifier
+    LearnerExtraTrees : Extremely randomized trees classifier
+    LearnerGradientBoosting : Gradient boosting classifier
     """
     
     def __init__(
@@ -182,25 +287,63 @@ class LearnerRandomForest(LearnerClassifSKLearn):
 
 class LearnerGradientBoosting(LearnerClassifSKLearn):
     """Gradient Boosting classifier wrapper.
-    
+
+    Wraps sklearn's GradientBoostingClassifier with MLPY's unified interface. Builds an additive ensemble of
+    shallow trees that sequentially correct previous errors. Suitable for
+    tabular data with complex patterns; strong accuracy but sensitive to
+    hyperparameters.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    predict_type : str, optional
-        Type of prediction ("response" or "prob").
-    n_estimators : int, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    predict_type : {"response", "prob"}, default="response"
+        Type of prediction to produce.
+    n_estimators : int, default=100
         Number of boosting stages.
-    learning_rate : float, optional
-        Learning rate.
-    max_depth : int, optional
-        Maximum depth of trees.
-    subsample : float, optional
-        Fraction of samples for fitting base learners.
-    random_state : int, optional
-        Random seed.
+    learning_rate : float, default=0.1
+        Shrinks the contribution of each tree.
+    max_depth : int, default=3
+        Maximum depth of individual regression trees.
+    subsample : float, default=1.0
+        Fraction of samples used for fitting the base learners.
+    random_state : int, default=None
+        Random seed for reproducibility.
     **kwargs
-        Additional parameters for GradientBoostingClassifier.
+        Additional estimator parameters forwarded to
+        ``sklearn.ensemble.GradientBoostingClassifier``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from mlpy.tasks import TaskClassif
+    >>> from mlpy.learners.sklearn import LearnerGradientBoosting
+    >>> from sklearn.datasets import load_iris
+    >>> iris = load_iris()
+    >>> df = pd.DataFrame(iris.data, columns=iris.feature_names)
+    >>> df['target'] = iris.target
+    >>> task = TaskClassif(data=df, target='target')
+    >>> learner = LearnerGradientBoosting(n_estimators=150, learning_rate=0.05)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> np.unique(pred.response).size <= task.n_classes
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.ensemble.GradientBoostingClassifier``.
+    For more details, see the sklearn documentation.
+
+    References
+    ----------
+    .. [1] Friedman, J. H. (2001). Greedy Function Approximation:
+           A Gradient Boosting Machine. Annals of Statistics.
+
+    See Also
+    --------
+    LearnerAdaBoost : Adaptive boosting classifier
+    LearnerRandomForest : Random forest classifier
     """
     
     def __init__(
@@ -230,24 +373,60 @@ class LearnerGradientBoosting(LearnerClassifSKLearn):
         )
 
 class LearnerAdaBoost(LearnerClassifSKLearn):
-    """ AdaBoost classifier wrapper
+    """AdaBoost classifier wrapper.
+
+    Wraps sklearn's AdaBoostClassifier with MLPY's unified interface. Reweights misclassified samples to focus
+    on hard cases and combines many weak learners. Suitable with simple base
+    estimators; can be sensitive to noise and outliers.
 
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    predict_type : str, optional
-        Type of prediction ("response" or "prob").
-    estimator : object, optional
-        Base estimator to boost.
-    n_estimators : int, optional
-        Maximum number of estimators.
-    learning_rate : float, optional
-        Weighting applied to each classifier.
-    random_state : int, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    predict_type : {"response", "prob"}, default="response"
+        Type of prediction to produce.
+    estimator : object, default=None
+        Base estimator to boost. If None, uses a decision stump.
+    n_estimators : int, default=50
+        The maximum number of estimators at which boosting is terminated.
+    learning_rate : float, default=1.0
+        Weight applied to each classifier at each boosting iteration.
+    random_state : int, default=None
         Random seed for reproducibility.
     **kwargs
-        Additional parameters for AdaBoostClassifier
+        Additional estimator parameters forwarded to
+        ``sklearn.ensemble.AdaBoostClassifier``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskClassif
+    >>> from mlpy.learners.sklearn import LearnerAdaBoost
+    >>> from sklearn.datasets import load_iris
+    >>> iris = load_iris()
+    >>> df = pd.DataFrame(iris.data, columns=iris.feature_names)
+    >>> df['target'] = iris.target
+    >>> task = TaskClassif(data=df, target='target')
+    >>> learner = LearnerAdaBoost(n_estimators=75)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> pred.response.shape[0] == len(df)
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.ensemble.AdaBoostClassifier``.
+    For more details, see the sklearn documentation.
+
+    References
+    ----------
+    .. [1] Freund, Y. and Schapire, R. E. (1997). A Decision-Theoretic
+           Generalization of On-Line Learning and an Application to Boosting.
+
+    See Also
+    --------
+    LearnerGradientBoosting : Gradient boosting classifier
+    LearnerDecisionTree : Decision tree classifier
     """
 
     def __init__(
@@ -275,34 +454,69 @@ class LearnerAdaBoost(LearnerClassifSKLearn):
         )
 
 class LearnerExtraTrees(LearnerClassifSKLearn):
-    """ Extra Trees classifier wrapper
+    """Extremely Randomized Trees (Extra Trees) classifier wrapper.
+
+    Wraps sklearn's ExtraTreesClassifier with MLPY's unified interface. Uses fully random feature/threshold
+    splits across many trees to reduce variance. Suitable for fast, robust
+    models on high-dimensional data.
 
     Parameters
     ----------
-
-    id : str, optional
-        Unique identifier.
-    predict_type : str, optional
-        Type of prediction ("response" or "prob").
-    n_estimators : int, optional
-        Number of trees.
-    criterion : str, optional
-        Function to measure split quality.
-    max_depth : int, optional
-        Maximum depth of trees.
-    min_samples_split : int, optional
-        Minimum samples required to split.
-    min_samples_leaf : int, optional
-        Minimum samples required at leaf.
-    max_features : str or float, optional
-        Number of features to consider when looking for the best split. Use
-        'sqrt', 'log2', an int, or a float in (0, 1].
-    random_state : int, optional
-        Random seed.
-    n_jobs : int, optional
-        Number of parallel jobs to run for both fit and predict.
+    id : str, default=None
+        Unique identifier for the learner.
+    predict_type : {"response", "prob"}, default="response"
+        Type of prediction to produce.
+    n_estimators : int, default=100
+        Number of trees in the forest.
+    criterion : {"gini", "entropy", "log_loss"}, default="gini"
+        Function to measure the quality of a split.
+    max_depth : int or None, default=None
+        Maximum depth of the trees.
+    min_samples_split : int, default=2
+        Minimum number of samples required to split an internal node.
+    min_samples_leaf : int, default=1
+        Minimum number of samples required to be at a leaf node.
+    max_features : {"sqrt", "log2"} or float, default="sqrt"
+        Number of features to consider when looking for the best split.
+    random_state : int, default=None
+        Random seed for reproducibility.
+    n_jobs : int, default=None
+        Number of parallel jobs to run.
     **kwargs
-        Additional parameters for ExtraTreesClassifier.
+        Additional estimator parameters forwarded to
+        ``sklearn.ensemble.ExtraTreesClassifier``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from mlpy.tasks import TaskClassif
+    >>> from mlpy.learners.sklearn import LearnerExtraTrees
+    >>> from sklearn.datasets import load_iris
+    >>> iris = load_iris()
+    >>> df = pd.DataFrame(iris.data, columns=iris.feature_names)
+    >>> df['target'] = iris.target
+    >>> task = TaskClassif(data=df, target='target')
+    >>> learner = LearnerExtraTrees(n_estimators=300, random_state=42)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> bool(np.isnan(pred.response).sum() == 0)
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.ensemble.ExtraTreesClassifier``.
+    For more details, see the sklearn documentation.
+
+    References
+    ----------
+    .. [1] Geurts, P., Ernst, D., and Wehenkel, L. (2006).
+           Extremely Randomized Trees. Machine Learning, 63, 3–42.
+
+    See Also
+    --------
+    LearnerRandomForest : Random forest classifier
+    LearnerDecisionTree : Decision tree classifier
     """
 
     def __init__(
@@ -339,27 +553,62 @@ class LearnerExtraTrees(LearnerClassifSKLearn):
 
 class LearnerSVM(LearnerClassifSKLearn):
     """Support Vector Machine classifier wrapper.
-    
+
+    Wraps sklearn's SVC with MLPY's unified interface. Maximizes the margin between
+    classes and can use kernels for non-linear boundaries. Suitable for
+    high-dimensional data; probability estimates available when enabled.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    predict_type : str, optional
-        Type of prediction ("response" or "prob").
-    C : float, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    predict_type : {"response", "prob"}, default="response"
+        Type of prediction to produce.
+    C : float, default=1.0
         Regularization parameter.
-    kernel : str, optional
-        Kernel type.
-    degree : int, optional
-        Degree for polynomial kernel.
-    gamma : str or float, optional
-        Kernel coefficient.
-    probability : bool, optional
-        Enable probability estimates.
-    random_state : int, optional
-        Random seed.
+    kernel : {"linear", "poly", "rbf", "sigmoid"}, default="rbf"
+        Specifies the kernel type to be used in the algorithm.
+    degree : int, default=3
+        Degree of the polynomial kernel function ("poly").
+    gamma : {"scale", "auto"} or float, default="scale"
+        Kernel coefficient for "rbf", "poly" and "sigmoid".
+    probability : bool, default=False
+        Enable probability estimates. Automatically set to True when
+        ``predict_type="prob"``.
+    random_state : int, default=None
+        Random seed for reproducibility.
     **kwargs
-        Additional parameters for SVC.
+        Additional estimator parameters forwarded to ``sklearn.svm.SVC``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskClassif
+    >>> from mlpy.learners.sklearn import LearnerSVM
+    >>> from sklearn.datasets import load_iris
+    >>> iris = load_iris()
+    >>> df = pd.DataFrame(iris.data, columns=iris.feature_names)
+    >>> df['target'] = iris.target
+    >>> task = TaskClassif(data=df, target='target')
+    >>> learner = LearnerSVM(kernel="rbf", predict_type="prob")
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> pred.prob is not None
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.svm.SVC``.
+    For more details, see the sklearn documentation.
+
+    References
+    ----------
+    .. [1] Cortes, C. and Vapnik, V. (1995). Support-Vector Networks.
+
+    See Also
+    --------
+    LearnerLogisticRegression : Linear classifier with probabilistic output
+    LearnerKNN : k-nearest neighbors classifier
     """
     
     def __init__(
@@ -397,23 +646,60 @@ class LearnerSVM(LearnerClassifSKLearn):
 
 class LearnerKNN(LearnerClassifSKLearn):
     """K-Nearest Neighbors classifier wrapper.
-    
+
+    Wraps sklearn's KNeighborsClassifier with MLPY's unified interface. Predicts by majority vote of the
+    closest points in feature space. Suitable for small to medium datasets;
+    sensitive to feature scaling and the choice of k.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    predict_type : str, optional
-        Type of prediction ("response" or "prob").
-    n_neighbors : int, optional
-        Number of neighbors.
-    weights : str, optional
-        Weight function.
-    algorithm : str, optional
-        Algorithm to compute nearest neighbors.
-    metric : str, optional
-        Distance metric.
+    id : str, default=None
+        Unique identifier for the learner.
+    predict_type : {"response", "prob"}, default="response"
+        Type of prediction to produce.
+    n_neighbors : int, default=5
+        Number of neighbors to use.
+    weights : {"uniform", "distance"}, default="uniform"
+        Weight function used in prediction.
+    algorithm : {"auto", "ball_tree", "kd_tree", "brute"}, default="auto"
+        Algorithm used to compute the nearest neighbors.
+    metric : str, default="minkowski"
+        Distance metric to use for the tree.
     **kwargs
-        Additional parameters for KNeighborsClassifier.
+        Additional estimator parameters forwarded to
+        ``sklearn.neighbors.KNeighborsClassifier``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from mlpy.tasks import TaskClassif
+    >>> from mlpy.learners.sklearn import LearnerKNN
+    >>> from sklearn.datasets import load_iris
+    >>> iris = load_iris()
+    >>> df = pd.DataFrame(iris.data, columns=iris.feature_names)
+    >>> df['target'] = iris.target
+    >>> task = TaskClassif(data=df, target='target')
+    >>> learner = LearnerKNN(n_neighbors=7)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> bool(np.isnan(pred.response).any())
+    False
+
+    Notes
+    -----
+    Wrapper around ``sklearn.neighbors.KNeighborsClassifier``.
+    For more details, see the sklearn documentation.
+
+    References
+    ----------
+    .. [1] Cover, T. and Hart, P. (1967). Nearest neighbor pattern
+           classification. IEEE Transactions on Information Theory.
+
+    See Also
+    --------
+    LearnerSVM : Support Vector Machine classifier
+    LearnerLogisticRegression : Logistic regression classifier
     """
     
     def __init__(
@@ -443,17 +729,51 @@ class LearnerKNN(LearnerClassifSKLearn):
 
 class LearnerNaiveBayes(LearnerClassifSKLearn):
     """Gaussian Naive Bayes classifier wrapper.
-    
+
+    Wraps sklearn's GaussianNB with MLPY's unified interface. A probabilistic classifier assuming conditional
+    independence with Gaussian likelihoods. Suitable as a fast baseline, often
+    effective with limited data and high-dimensional features.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    predict_type : str, optional
-        Type of prediction ("response" or "prob").
-    var_smoothing : float, optional
-        Portion of largest variance added to variances.
+    id : str, default=None
+        Unique identifier for the learner.
+    predict_type : {"response", "prob"}, default="response"
+        Type of prediction to produce.
+    var_smoothing : float, default=1e-9
+        Portion of the largest variance of all features added to variances.
     **kwargs
-        Additional parameters for GaussianNB.
+        Additional estimator parameters forwarded to ``sklearn.naive_bayes.GaussianNB``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskClassif
+    >>> from mlpy.learners.sklearn import LearnerNaiveBayes
+    >>> from sklearn.datasets import load_iris
+    >>> iris = load_iris()
+    >>> df = pd.DataFrame(iris.data, columns=iris.feature_names)
+    >>> df['target'] = iris.target
+    >>> task = TaskClassif(data=df, target='target')
+    >>> learner = LearnerNaiveBayes()
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> pred.response[:3].shape[0] == 3
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.naive_bayes.GaussianNB``.
+    For more details, see the sklearn documentation.
+
+    References
+    ----------
+    .. [1] Mitchell, TM. (1997). Machine Learning. McGraw-Hill. (Naive Bayes)
+
+    See Also
+    --------
+    LearnerLogisticRegression : Logistic regression classifier
+    LearnerKNN : k-nearest neighbors classifier
     """
     
     def __init__(
@@ -476,30 +796,66 @@ class LearnerNaiveBayes(LearnerClassifSKLearn):
 
 
 class LearnerMLPClassifier(LearnerClassifSKLearn):
-    """Multi-layer Perceptron classifier wrapper.
-    
+    """Multi-layer Perceptron (neural network) classifier wrapper.
+
+    Wraps sklearn's MLPClassifier with MLPY's unified interface. A feedforward neural
+    network trained with backpropagation for classification. Suitable for
+    non-linear decision boundaries; may require tuning and feature scaling.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    predict_type : str, optional
-        Type of prediction ("response" or "prob").
-    hidden_layer_sizes : tuple, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    predict_type : {"response", "prob"}, default="response"
+        Type of prediction to produce.
+    hidden_layer_sizes : tuple, default=(100,)
         Number of neurons in each hidden layer.
-    activation : str, optional
-        Activation function.
-    solver : str, optional
-        Weight optimization solver.
-    alpha : float, optional
-        L2 penalty parameter.
-    learning_rate : str, optional
-        Learning rate schedule.
-    max_iter : int, optional
-        Maximum iterations.
-    random_state : int, optional
-        Random seed.
+    activation : {"identity", "logistic", "tanh", "relu"}, default="relu"
+        Activation function for the hidden layer.
+    solver : {"lbfgs", "sgd", "adam"}, default="adam"
+        The solver for weight optimization.
+    alpha : float, default=0.0001
+        L2 penalty (regularization term) parameter.
+    learning_rate : {"constant", "invscaling", "adaptive"}, default="constant"
+        Learning rate schedule for weight updates.
+    max_iter : int, default=200
+        Maximum number of iterations.
+    random_state : int, default=None
+        Random seed for reproducibility.
     **kwargs
-        Additional parameters for MLPClassifier.
+        Additional estimator parameters forwarded to
+        ``sklearn.neural_network.MLPClassifier``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskClassif
+    >>> from mlpy.learners.sklearn import LearnerMLPClassifier
+    >>> from sklearn.datasets import load_iris
+    >>> iris = load_iris()
+    >>> df = pd.DataFrame(iris.data, columns=iris.feature_names)
+    >>> df['target'] = iris.target
+    >>> task = TaskClassif(data=df, target='target')
+    >>> learner = LearnerMLPClassifier(max_iter=300, random_state=0)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> pred.response.size == len(df)
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.neural_network.MLPClassifier``.
+    For more details, see the sklearn documentation.
+
+    References
+    ----------
+    .. [1] Rumelhart, Hinton, and Williams (1986). Learning Representations
+           by Back-Propagating Errors. Nature.
+
+    See Also
+    --------
+    LearnerSVM : Support Vector Machine classifier
+    LearnerRandomForest : Random forest classifier
     """
     
     def __init__(

--- a/mlpy/learners/sklearn/regression.py
+++ b/mlpy/learners/sklearn/regression.py
@@ -10,7 +10,7 @@ try:
         LinearRegression, Ridge, Lasso, ElasticNet
     )
     from sklearn.tree import DecisionTreeRegressor
-    from sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor
+    from sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor, AdaBoostRegressor, ExtraTreesRegressor
     from sklearn.svm import SVR
     from sklearn.neighbors import KNeighborsRegressor
     from sklearn.neural_network import MLPRegressor
@@ -368,6 +368,104 @@ class LearnerGradientBoostingRegressor(LearnerRegrSKLearn):
             **kwargs
         )
 
+class LearnerAdaBoostRegressor(LearnerRegrSKLearn):
+    """ AdaBoost Regressor wrapper.
+
+    Parameters
+    ----------
+    id : str, optional
+        Unique identifier.
+    estimator : object, optional
+        Base estimator to boost.
+    n_estimators : int, optional
+        Number of boosting stages.
+    learning_rate : float, optional
+        Learning rate.
+    random_state : int, optional
+        Random seed.
+    **kwargs
+        Additional parameters for AdaBoostRegressor.
+    """
+
+    def __init__(
+        self,
+        id: Optional[str] = None,
+        estimator: Optional[object] = None,
+        n_estimators: int = 50,
+        learning_rate: float = 1.0,
+        random_state: Optional[int] = None,
+        **kwargs
+    ):
+        if not _HAS_SKLEARN:
+            raise ImportError("scikit-learn is required for this learner")
+
+        super().__init__(
+            estimator_class=AdaBoostRegressor,
+            id=id or "adaboost_regr",
+            estimator=estimator,
+            n_estimators=n_estimators,
+            learning_rate=learning_rate,
+            random_state=random_state,
+            **kwargs
+        )
+
+class LearnerExtraTreesRegressor(LearnerRegrSKLearn):
+    """ Extra Trees Regressor wrapper.
+
+    Parameters
+    ----------
+    id : str, optional
+        Unique identifier.
+    n_estimators : int, optional
+        Number of trees.
+    criterion : str, optional
+        Function to measure split quality.
+    max_depth : int, optional  
+        Maximum depth of trees.
+    min_samples_split : int, optional
+        Minimum samples required to split.
+    min_samples_leaf : int, optional
+        Minimum samples required at leaf.
+    max_features : float or str, optional
+        Number of features to consider when looking for the best split. Use a
+        float in (0, 1], an int, or strings like 'sqrt'/'log2'.
+    random_state : int, optional
+        Random seed.
+    n_jobs : int, optional
+        Number of parallel jobs.
+    **kwargs
+        Additional parameters for ExtraTreesRegressor.
+    """
+
+    def __init__(
+        self,
+        id: Optional[str] = None,
+        n_estimators: int = 100,
+        criterion: str = 'squared_error',
+        max_depth: Optional[int] = None,
+        min_samples_split: int = 2,
+        min_samples_leaf: int = 1,
+        max_features: float = 1.0,
+        random_state: Optional[int] = None,
+        n_jobs: Optional[int] = None,
+        **kwargs
+    ):
+        if not _HAS_SKLEARN:
+            raise ImportError("scikit-learn is required for this learner")
+
+        super().__init__(
+            estimator_class=ExtraTreesRegressor,
+            id=id or "extra_trees_regr",
+            n_estimators=n_estimators,
+            criterion=criterion,
+            max_depth=max_depth,
+            min_samples_split=min_samples_split,
+            min_samples_leaf=min_samples_leaf,
+            max_features=max_features,
+            random_state=random_state,
+            n_jobs=n_jobs,
+            **kwargs
+        )
 
 class LearnerSVR(LearnerRegrSKLearn):
     """Support Vector Regression wrapper.

--- a/mlpy/learners/sklearn/regression.py
+++ b/mlpy/learners/sklearn/regression.py
@@ -21,19 +21,56 @@ except ImportError:
 
 class LearnerLinearRegression(LearnerRegrSKLearn):
     """Linear Regression wrapper.
-    
+
+    Wraps sklearn's LinearRegression with MLPY's unified interface. Ordinary
+    least squares linear model; a strong baseline when relationships are
+    approximately linear.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    fit_intercept : bool, optional
-        Whether to calculate intercept.
-    copy_X : bool, optional
-        Whether to copy X or overwrite.
-    n_jobs : int, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    fit_intercept : bool, default=True
+        Whether to fit the intercept.
+    copy_X : bool, default=True
+        Whether to copy X.
+    n_jobs : int, default=None
         Number of parallel jobs.
     **kwargs
-        Additional parameters for LinearRegression.
+        Additional estimator parameters forwarded to
+        ``sklearn.linear_model.LinearRegression``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskRegr
+    >>> from mlpy.learners.sklearn import LearnerLinearRegression
+    >>> from sklearn.datasets import load_diabetes
+    >>> data = load_diabetes()
+    >>> df = pd.DataFrame(data.data, columns=data.feature_names)
+    >>> df['target'] = data.target
+    >>> task = TaskRegr(data=df, target='target')
+    >>> learner = LearnerLinearRegression()
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> len(pred.response) == len(df)
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.linear_model.LinearRegression``.
+    See the scikit-learn documentation.
+
+    References
+    ----------
+    .. [1] Seber, G. A. F., and Lee, A. J. (2003).
+        Linear Regression Analysis. Wiley.
+
+    See Also
+    --------
+    LearnerRidge : Ridge regression (L2 penalty)
+    LearnerLasso : Lasso regression (L1 penalty)
+    LearnerElasticNet : Elastic net regression (L1+L2)
     """
     
     def __init__(
@@ -59,23 +96,59 @@ class LearnerLinearRegression(LearnerRegrSKLearn):
 
 class LearnerRidge(LearnerRegrSKLearn):
     """Ridge Regression wrapper.
-    
+
+    Wraps sklearn's Ridge with MLPY's unified interface. Linear regression with
+    L2 regularization to reduce variance and handle multicollinearity.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    alpha : float, optional
-        Regularization strength.
-    fit_intercept : bool, optional
-        Whether to calculate intercept.
-    solver : str, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    alpha : float, default=1.0
+        Regularization strength (L2 penalty).
+    fit_intercept : bool, default=True
+        Whether to fit the intercept.
+    solver : {"auto", "svd", "cholesky", "lsqr", "sparse_cg", "sag", "saga"}, default="auto"
         Solver to use.
-    max_iter : int, optional
+    max_iter : int, default=None
         Maximum iterations for iterative solvers.
-    random_state : int, optional
+    random_state : int, default=None
         Random seed.
     **kwargs
-        Additional parameters for Ridge.
+        Additional estimator parameters forwarded to
+        ``sklearn.linear_model.Ridge``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskRegr
+    >>> from mlpy.learners.sklearn import LearnerRidge
+    >>> from sklearn.datasets import load_diabetes
+    >>> data = load_diabetes()
+    >>> df = pd.DataFrame(data.data, columns=data.feature_names)
+    >>> df['target'] = data.target
+    >>> task = TaskRegr(data=df, target='target')
+    >>> learner = LearnerRidge(alpha=0.5)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> pred.response.shape[0] == len(df)
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.linear_model.Ridge``.
+    See the scikit-learn documentation.
+
+    References
+    ----------
+    .. [1] Hoerl, A. E., and Kennard, R. W. (1970).
+        Ridge Regression: Biased Estimation for Nonorthogonal Problems.
+        Technometrics, 12(1), 55–67.
+
+    See Also
+    --------
+    LearnerLasso : L1-regularized regression
+    LearnerElasticNet : Combined L1/L2 regularization
     """
     
     def __init__(
@@ -105,23 +178,59 @@ class LearnerRidge(LearnerRegrSKLearn):
 
 class LearnerLasso(LearnerRegrSKLearn):
     """Lasso Regression wrapper.
-    
+
+    Wraps sklearn's Lasso with MLPY's unified interface. Linear regression with
+    L1 regularization that can drive coefficients to zero for feature selection.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    alpha : float, optional
-        Regularization strength.
-    fit_intercept : bool, optional
-        Whether to calculate intercept.
-    max_iter : int, optional
-        Maximum iterations.
-    selection : str, optional
-        Selection method ('cyclic' or 'random').
-    random_state : int, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    alpha : float, default=1.0
+        Regularization strength (L1 penalty).
+    fit_intercept : bool, default=True
+        Whether to fit the intercept.
+    max_iter : int, default=1000
+        Maximum number of iterations.
+    selection : {"cyclic", "random"}, default="cyclic"
+        Coordinate descent selection strategy.
+    random_state : int, default=None
         Random seed.
     **kwargs
-        Additional parameters for Lasso.
+        Additional estimator parameters forwarded to
+        ``sklearn.linear_model.Lasso``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskRegr
+    >>> from mlpy.learners.sklearn import LearnerLasso
+    >>> from sklearn.datasets import load_diabetes
+    >>> data = load_diabetes()
+    >>> df = pd.DataFrame(data.data, columns=data.feature_names)
+    >>> df['target'] = data.target
+    >>> task = TaskRegr(data=df, target='target')
+    >>> learner = LearnerLasso(alpha=0.01, max_iter=2000)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> pred.response.size == len(df)
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.linear_model.Lasso``.
+    See the scikit-learn documentation.
+
+    References
+    ----------
+    .. [1] Tibshirani, R. (1996). Regression Shrinkage and Selection
+        via the Lasso. Journal of the Royal Statistical Society:
+        Series B (Methodological), 58(1), 267–288.
+
+    See Also
+    --------
+    LearnerRidge : L2-regularized regression
+    LearnerElasticNet : Combined L1/L2 regularization
     """
     
     def __init__(
@@ -150,26 +259,62 @@ class LearnerLasso(LearnerRegrSKLearn):
 
 
 class LearnerElasticNet(LearnerRegrSKLearn):
-    """ElasticNet Regression wrapper.
-    
+    """Elastic Net Regression wrapper.
+
+    Wraps sklearn's ElasticNet with MLPY's unified interface. Linear regression
+    with combined L1/L2 penalties; balances sparsity and stability.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    alpha : float, optional
-        Regularization strength.
-    l1_ratio : float, optional
-        Mix parameter between L1 and L2 penalty.
-    fit_intercept : bool, optional
-        Whether to calculate intercept.
-    max_iter : int, optional
-        Maximum iterations.
-    selection : str, optional
-        Selection method ('cyclic' or 'random').
-    random_state : int, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    alpha : float, default=1.0
+        Overall regularization strength.
+    l1_ratio : float, default=0.5
+        The mixing parameter between L1 (1.0) and L2 (0.0).
+    fit_intercept : bool, default=True
+        Whether to fit the intercept.
+    max_iter : int, default=1000
+        Maximum number of iterations.
+    selection : {"cyclic", "random"}, default="cyclic"
+        Coordinate descent selection strategy.
+    random_state : int, default=None
         Random seed.
     **kwargs
-        Additional parameters for ElasticNet.
+        Additional estimator parameters forwarded to
+        ``sklearn.linear_model.ElasticNet``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskRegr
+    >>> from mlpy.learners.sklearn import LearnerElasticNet
+    >>> from sklearn.datasets import load_diabetes
+    >>> data = load_diabetes()
+    >>> df = pd.DataFrame(data.data, columns=data.feature_names)
+    >>> df['target'] = data.target
+    >>> task = TaskRegr(data=df, target='target')
+    >>> learner = LearnerElasticNet(alpha=0.1, l1_ratio=0.7)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> pred.response.shape[0] == len(df)
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.linear_model.ElasticNet``.
+    See the scikit-learn documentation.
+
+    References
+    ----------
+    .. [1] Zou, H., and Hastie, T. (2005). Regularization and variable
+        selection via the elastic net. Journal of the Royal Statistical
+        Society: Series B (Statistical Methodology), 67(2), 301–320.
+
+    See Also
+    --------
+    LearnerRidge : L2-regularized regression
+    LearnerLasso : L1-regularized regression
     """
     
     def __init__(
@@ -201,25 +346,61 @@ class LearnerElasticNet(LearnerRegrSKLearn):
 
 class LearnerDecisionTreeRegressor(LearnerRegrSKLearn):
     """Decision Tree Regressor wrapper.
-    
+
+    Wraps sklearn's DecisionTreeRegressor with MLPY's unified interface.
+    Recursively partitions the feature space using axis-aligned splits; handles
+    non-linear relationships and mixed feature types.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    criterion : str, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    criterion : {"squared_error", "friedman_mse", "absolute_error", "poisson"}, default="squared_error"
         Function to measure split quality.
-    splitter : str, optional
-        Strategy to choose split.
-    max_depth : int, optional
-        Maximum depth of tree.
-    min_samples_split : int, optional
-        Minimum samples required to split.
-    min_samples_leaf : int, optional
-        Minimum samples required at leaf.
-    random_state : int, optional
+    splitter : {"best", "random"}, default="best"
+        Strategy used to choose the split at each node.
+    max_depth : int, default=None
+        Maximum depth of the tree.
+    min_samples_split : int, default=2
+        Minimum number of samples required to split.
+    min_samples_leaf : int, default=1
+        Minimum number of samples required at a leaf node.
+    random_state : int, default=None
         Random seed.
     **kwargs
-        Additional parameters for DecisionTreeRegressor.
+        Additional estimator parameters forwarded to
+        ``sklearn.tree.DecisionTreeRegressor``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskRegr
+    >>> from mlpy.learners.sklearn import LearnerDecisionTreeRegressor
+    >>> from sklearn.datasets import load_diabetes
+    >>> data = load_diabetes()
+    >>> df = pd.DataFrame(data.data, columns=data.feature_names)
+    >>> df['target'] = data.target
+    >>> task = TaskRegr(data=df, target='target')
+    >>> learner = LearnerDecisionTreeRegressor(max_depth=4)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> pred.response[:5].shape[0] == 5
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.tree.DecisionTreeRegressor``.
+    See the scikit-learn documentation.
+
+    References
+    ----------
+    .. [1] Breiman, L., Friedman, J. H., Olshen, R. A., and Stone, C. J. (1984).
+        Classification and Regression Trees. Wadsworth.
+
+    See Also
+    --------
+    LearnerRandomForestRegressor : Random forest regressor
+    LearnerExtraTreesRegressor : Extremely randomized trees regressor
     """
     
     def __init__(
@@ -251,29 +432,66 @@ class LearnerDecisionTreeRegressor(LearnerRegrSKLearn):
 
 class LearnerRandomForestRegressor(LearnerRegrSKLearn):
     """Random Forest Regressor wrapper.
-    
+
+    Wraps sklearn's RandomForestRegressor with MLPY's unified interface. An
+    ensemble of decision trees trained on bootstrapped samples with feature
+    randomness; strong default performance and robust to overfitting.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    n_estimators : int, optional
-        Number of trees.
-    criterion : str, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    n_estimators : int, default=100
+        Number of trees in the forest.
+    criterion : {"squared_error", "absolute_error", "poisson"}, default="squared_error"
         Function to measure split quality.
-    max_depth : int, optional
-        Maximum depth of trees.
-    min_samples_split : int, optional
-        Minimum samples required to split.
-    min_samples_leaf : int, optional
-        Minimum samples required at leaf.
-    max_features : str or float, optional
-        Number of features to consider for best split.
-    random_state : int, optional
+    max_depth : int, default=None
+        Maximum depth of the trees.
+    min_samples_split : int, default=2
+        Minimum number of samples required to split.
+    min_samples_leaf : int, default=1
+        Minimum number of samples required at a leaf node.
+    max_features : float or str, default=1.0
+        Features considered when looking for the best split.
+    random_state : int, default=None
         Random seed.
-    n_jobs : int, optional
+    n_jobs : int, default=None
         Number of parallel jobs.
     **kwargs
-        Additional parameters for RandomForestRegressor.
+        Additional estimator parameters forwarded to
+        ``sklearn.ensemble.RandomForestRegressor``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskRegr
+    >>> from mlpy.learners.sklearn import LearnerRandomForestRegressor
+    >>> from sklearn.datasets import load_diabetes
+    >>> data = load_diabetes()
+    >>> df = pd.DataFrame(data.data, columns=data.feature_names)
+    >>> df['target'] = data.target
+    >>> task = TaskRegr(data=df, target='target')
+    >>> learner = LearnerRandomForestRegressor(n_estimators=200, random_state=0)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> hasattr(pred, "response")
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.ensemble.RandomForestRegressor``.
+    See the scikit-learn documentation.
+
+    References
+    ----------
+    .. [1] Breiman, L. (2001). Random Forests. Machine Learning,
+        45(1), 5–32.
+
+    See Also
+    --------
+    LearnerDecisionTreeRegressor : Single decision tree regressor
+    LearnerExtraTreesRegressor : Extremely randomized trees regressor
+    LearnerGradientBoostingRegressor : Gradient boosting regressor
     """
     
     def __init__(
@@ -309,31 +527,68 @@ class LearnerRandomForestRegressor(LearnerRegrSKLearn):
 
 class LearnerGradientBoostingRegressor(LearnerRegrSKLearn):
     """Gradient Boosting Regressor wrapper.
-    
+
+    Wraps sklearn's GradientBoostingRegressor with MLPY's unified interface.
+    Builds an additive ensemble of shallow trees, sequentially correcting
+    previous errors; strong on tabular data but sensitive to hyperparameters.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    loss : str, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    loss : {"squared_error", "absolute_error", "huber", "quantile"}, default="squared_error"
         Loss function to optimize.
-    learning_rate : float, optional
-        Learning rate.
-    n_estimators : int, optional
+    learning_rate : float, default=0.1
+        Shrinks the contribution of each tree.
+    n_estimators : int, default=100
         Number of boosting stages.
-    subsample : float, optional
-        Fraction of samples for fitting base learners.
-    criterion : str, optional
+    subsample : float, default=1.0
+        Fraction of samples used for fitting the base learners.
+    criterion : {"friedman_mse", "squared_error"}, default="friedman_mse"
         Function to measure split quality.
-    min_samples_split : int, optional
-        Minimum samples required to split.
-    min_samples_leaf : int, optional
-        Minimum samples required at leaf.
-    max_depth : int, optional
-        Maximum depth of trees.
-    random_state : int, optional
+    min_samples_split : int, default=2
+        Minimum number of samples required to split.
+    min_samples_leaf : int, default=1
+        Minimum number of samples required at a leaf.
+    max_depth : int, default=3
+        Maximum depth of the individual trees.
+    random_state : int, default=None
         Random seed.
     **kwargs
-        Additional parameters for GradientBoostingRegressor.
+        Additional estimator parameters forwarded to
+        ``sklearn.ensemble.GradientBoostingRegressor``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from mlpy.tasks import TaskRegr
+    >>> from mlpy.learners.sklearn import LearnerGradientBoostingRegressor
+    >>> from sklearn.datasets import load_diabetes
+    >>> data = load_diabetes()
+    >>> df = pd.DataFrame(data.data, columns=data.feature_names)
+    >>> df['target'] = data.target
+    >>> task = TaskRegr(data=df, target='target')
+    >>> learner = LearnerGradientBoostingRegressor(n_estimators=150, learning_rate=0.05)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> bool(np.isfinite(pred.response).all())
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.ensemble.GradientBoostingRegressor``.
+    See the scikit-learn documentation.
+
+    References
+    ----------
+    .. [1] Friedman, J. H. (2001). Greedy Function Approximation:
+        A Gradient Boosting Machine. Annals of Statistics, 29(5), 1189–1232.
+
+    See Also
+    --------
+    LearnerAdaBoostRegressor : Adaptive boosting regressor
+    LearnerRandomForestRegressor : Random forest regressor
     """
     
     def __init__(
@@ -369,22 +624,59 @@ class LearnerGradientBoostingRegressor(LearnerRegrSKLearn):
         )
 
 class LearnerAdaBoostRegressor(LearnerRegrSKLearn):
-    """ AdaBoost Regressor wrapper.
+    """AdaBoost Regressor wrapper.
+
+    Wraps sklearn's AdaBoostRegressor with MLPY's unified interface. Iteratively
+    reweights errors to focus on hard cases; works well with simple base
+    estimators; can be sensitive to noise.
 
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    estimator : object, optional
-        Base estimator to boost.
-    n_estimators : int, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    estimator : object, default=None
+        Base estimator to boost; if None, uses a decision tree stump.
+    n_estimators : int, default=50
         Number of boosting stages.
-    learning_rate : float, optional
-        Learning rate.
-    random_state : int, optional
+    learning_rate : float, default=1.0
+        Weight applied to each regressor at each boosting iteration.
+    random_state : int, default=None
         Random seed.
     **kwargs
-        Additional parameters for AdaBoostRegressor.
+        Additional estimator parameters forwarded to
+        ``sklearn.ensemble.AdaBoostRegressor``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskRegr
+    >>> from mlpy.learners.sklearn import LearnerAdaBoostRegressor
+    >>> from sklearn.datasets import load_diabetes
+    >>> data = load_diabetes()
+    >>> df = pd.DataFrame(data.data, columns=data.feature_names)
+    >>> df['target'] = data.target
+    >>> task = TaskRegr(data=df, target='target')
+    >>> learner = LearnerAdaBoostRegressor(n_estimators=75)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> pred.response.shape[0] == len(df)
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.ensemble.AdaBoostRegressor``.
+    See the scikit-learn documentation.
+
+    References
+    ----------
+    .. [1] Drucker, H. (1997). Improving Regressors using Boosting Techniques.
+        ICML.
+
+
+    See Also
+    --------
+    LearnerGradientBoostingRegressor : Gradient boosting regressor
+    LearnerDecisionTreeRegressor : Decision tree regressor
     """
 
     def __init__(
@@ -410,31 +702,67 @@ class LearnerAdaBoostRegressor(LearnerRegrSKLearn):
         )
 
 class LearnerExtraTreesRegressor(LearnerRegrSKLearn):
-    """ Extra Trees Regressor wrapper.
+    """Extra Trees Regressor wrapper.
+
+    Wraps sklearn's ExtraTreesRegressor with MLPY's unified interface. Uses
+    random feature/threshold splits across many trees to reduce variance; fast
+    and robust for high-dimensional data.
 
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    n_estimators : int, optional
-        Number of trees.
-    criterion : str, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    n_estimators : int, default=100
+        Number of trees in the forest.
+    criterion : {"squared_error", "absolute_error"}, default="squared_error"
         Function to measure split quality.
-    max_depth : int, optional  
-        Maximum depth of trees.
-    min_samples_split : int, optional
-        Minimum samples required to split.
-    min_samples_leaf : int, optional
-        Minimum samples required at leaf.
-    max_features : float or str, optional
-        Number of features to consider when looking for the best split. Use a
-        float in (0, 1], an int, or strings like 'sqrt'/'log2'.
-    random_state : int, optional
+    max_depth : int, default=None
+        Maximum depth of the trees.
+    min_samples_split : int, default=2
+        Minimum number of samples required to split.
+    min_samples_leaf : int, default=1
+        Minimum number of samples required at a leaf node.
+    max_features : float, default=1.0
+        Features considered when looking for the best split.
+    random_state : int, default=None
         Random seed.
-    n_jobs : int, optional
+    n_jobs : int, default=None
         Number of parallel jobs.
     **kwargs
-        Additional parameters for ExtraTreesRegressor.
+        Additional estimator parameters forwarded to
+        ``sklearn.ensemble.ExtraTreesRegressor``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from mlpy.tasks import TaskRegr
+    >>> from mlpy.learners.sklearn import LearnerExtraTreesRegressor
+    >>> from sklearn.datasets import load_diabetes
+    >>> data = load_diabetes()
+    >>> df = pd.DataFrame(data.data, columns=data.feature_names)
+    >>> df['target'] = data.target
+    >>> task = TaskRegr(data=df, target='target')
+    >>> learner = LearnerExtraTreesRegressor(n_estimators=300, random_state=42)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> bool(np.isnan(pred.response).sum() == 0)
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.ensemble.ExtraTreesRegressor``.
+    See the scikit-learn documentation.
+
+    References
+    ----------
+    .. [1] Geurts, P., Ernst, D., and Wehenkel, L. (2006).
+        Extremely Randomized Trees. Machine Learning, 63, 3–42.
+
+    See Also
+    --------
+    LearnerRandomForestRegressor : Random forest regressor
+    LearnerDecisionTreeRegressor : Decision tree regressor
     """
 
     def __init__(
@@ -469,23 +797,59 @@ class LearnerExtraTreesRegressor(LearnerRegrSKLearn):
 
 class LearnerSVR(LearnerRegrSKLearn):
     """Support Vector Regression wrapper.
-    
+
+    Wraps sklearn's SVR with MLPY's unified interface. Maximizes margin with an
+    epsilon-insensitive loss; kernels enable non-linear relationships.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    kernel : str, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    kernel : {"linear", "poly", "rbf", "sigmoid"}, default="rbf"
         Kernel type.
-    degree : int, optional
-        Degree for polynomial kernel.
-    gamma : str or float, optional
+    degree : int, default=3
+        Degree for the polynomial kernel.
+    gamma : {"scale", "auto"} or float, default="scale"
         Kernel coefficient.
-    C : float, optional
+    C : float, default=1.0
         Regularization parameter.
-    epsilon : float, optional
-        Epsilon in epsilon-SVR model.
+    epsilon : float, default=0.1
+        Epsilon in the epsilon-SVR model.
     **kwargs
-        Additional parameters for SVR.
+        Additional estimator parameters forwarded to ``sklearn.svm.SVR``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskRegr
+    >>> from mlpy.learners.sklearn import LearnerSVR
+    >>> from sklearn.datasets import load_diabetes
+    >>> data = load_diabetes()
+    >>> df = pd.DataFrame(data.data, columns=data.feature_names)
+    >>> df['target'] = data.target
+    >>> task = TaskRegr(data=df, target='target')
+    >>> learner = LearnerSVR(kernel="rbf", C=2.0, epsilon=0.2)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> pred.response.shape[0] == len(df)
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.svm.SVR``.
+    See the scikit-learn documentation.
+
+    References
+    ----------
+    .. [1] Vapnik, V. N. (1995). The Nature of Statistical Learning Theory.
+        Springer.
+    .. [2] Smola, A. J., and Schölkopf, B. (2004). A Tutorial on Support
+        Vector Regression. Statistics and Computing, 14(3), 199–222.
+
+    See Also
+    --------
+    LearnerKNNRegressor : k-nearest neighbors regressor
+    LearnerLinearRegression : Linear regression baseline
     """
     
     def __init__(
@@ -515,23 +879,60 @@ class LearnerSVR(LearnerRegrSKLearn):
 
 class LearnerKNNRegressor(LearnerRegrSKLearn):
     """K-Nearest Neighbors Regressor wrapper.
-    
+
+    Wraps sklearn's KNeighborsRegressor with MLPY's unified interface. Predicts
+    by averaging the targets of the closest neighbors; sensitive to scaling and
+    the choice of k.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    n_neighbors : int, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    n_neighbors : int, default=5
         Number of neighbors.
-    weights : str, optional
-        Weight function.
-    algorithm : str, optional
-        Algorithm to compute nearest neighbors.
-    leaf_size : int, optional
-        Leaf size for tree algorithms.
-    metric : str, optional
+    weights : {"uniform", "distance"}, default="uniform"
+        Weight function used in prediction.
+    algorithm : {"auto", "ball_tree", "kd_tree", "brute"}, default="auto"
+        Algorithm used to compute the nearest neighbors.
+    leaf_size : int, default=30
+        Leaf size for tree-based algorithms.
+    metric : str, default="minkowski"
         Distance metric.
     **kwargs
-        Additional parameters for KNeighborsRegressor.
+        Additional estimator parameters forwarded to
+        ``sklearn.neighbors.KNeighborsRegressor``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from mlpy.tasks import TaskRegr
+    >>> from mlpy.learners.sklearn import LearnerKNNRegressor
+    >>> from sklearn.datasets import load_diabetes
+    >>> data = load_diabetes()
+    >>> df = pd.DataFrame(data.data, columns=data.feature_names)
+    >>> df['target'] = data.target
+    >>> task = TaskRegr(data=df, target='target')
+    >>> learner = LearnerKNNRegressor(n_neighbors=7)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> bool(np.isfinite(pred.response).all())
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.neighbors.KNeighborsRegressor``.
+    See the scikit-learn documentation.
+
+    References
+    ----------
+    .. [1] Cover, T. and Hart, P. (1967). Nearest neighbor pattern
+        classification. IEEE Transactions on Information Theory.
+
+    See Also
+    --------
+    LearnerSVR : Support Vector Regression
+    LearnerLinearRegression : Linear regression baseline
     """
     
     def __init__(
@@ -560,32 +961,68 @@ class LearnerKNNRegressor(LearnerRegrSKLearn):
 
 
 class LearnerMLPRegressor(LearnerRegrSKLearn):
-    """Multi-layer Perceptron Regressor wrapper.
-    
+    """Multi-layer Perceptron (neural network) Regressor wrapper.
+
+    Wraps sklearn's MLPRegressor with MLPY's unified interface. A feedforward
+    neural network trained with backpropagation; models non-linear relationships
+    but may require tuning and feature scaling.
+
     Parameters
     ----------
-    id : str, optional
-        Unique identifier.
-    hidden_layer_sizes : tuple, optional
+    id : str, default=None
+        Unique identifier for the learner.
+    hidden_layer_sizes : tuple, default=(100,)
         Number of neurons in each hidden layer.
-    activation : str, optional
-        Activation function.
-    solver : str, optional
-        Weight optimization solver.
-    alpha : float, optional
-        L2 penalty parameter.
-    batch_size : str or int, optional
+    activation : {"identity", "logistic", "tanh", "relu"}, default="relu"
+        Activation function for the hidden layer.
+    solver : {"lbfgs", "sgd", "adam"}, default="adam"
+        The solver for weight optimization.
+    alpha : float, default=0.0001
+        L2 penalty (regularization term) parameter.
+    batch_size : {"auto"} or int, default="auto"
         Size of minibatches.
-    learning_rate : str, optional
-        Learning rate schedule.
-    learning_rate_init : float, optional
-        Initial learning rate.
-    max_iter : int, optional
-        Maximum iterations.
-    random_state : int, optional
-        Random seed.
+    learning_rate : {"constant", "invscaling", "adaptive"}, default="constant"
+        Learning rate schedule for weight updates.
+    learning_rate_init : float, default=0.001
+        Initial learning rate for weight updates.
+    max_iter : int, default=200
+        Maximum number of iterations.
+    random_state : int, default=None
+        Random seed for reproducibility.
     **kwargs
-        Additional parameters for MLPRegressor.
+        Additional estimator parameters forwarded to
+        ``sklearn.neural_network.MLPRegressor``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskRegr
+    >>> from mlpy.learners.sklearn import LearnerMLPRegressor
+    >>> from sklearn.datasets import load_diabetes
+    >>> data = load_diabetes()
+    >>> df = pd.DataFrame(data.data, columns=data.feature_names)
+    >>> df['target'] = data.target
+    >>> task = TaskRegr(data=df, target='target')
+    >>> learner = LearnerMLPRegressor(max_iter=300, random_state=0)
+    >>> _ = learner.train(task)
+    >>> pred = learner.predict(task)
+    >>> pred.response.size == len(df)
+    True
+
+    Notes
+    -----
+    Wrapper around ``sklearn.neural_network.MLPRegressor``.
+    See the scikit-learn documentation.
+
+    References
+    ----------
+    .. [1] Rumelhart, D. E., Hinton, G. E., and Williams, R. J. (1986).
+        Learning Representations by Back-Propagating Errors. Nature.
+
+    See Also
+    --------
+    LearnerSVR : Kernel-based regression
+    LearnerRandomForestRegressor : Ensemble tree-based regression
     """
     
     def __init__(

--- a/mlpy/measures/spatial.py
+++ b/mlpy/measures/spatial.py
@@ -1,10 +1,4 @@
-"""
-Spatial measures for MLPY.
-
-This module provides performance measures specifically designed for 
-spatial classification and regression tasks, accounting for spatial 
-autocorrelation and geographic structure in the data.
-"""
+"""Spatial measures for MLPY."""
 
 import numpy as np
 from sklearn.metrics import (

--- a/mlpy/measures/spatial.py
+++ b/mlpy/measures/spatial.py
@@ -20,9 +20,18 @@ from .base import MeasureClassif
 
 class MeasureSpatialAccuracy(MeasureClassif):
     """Accuracy measure for spatial classification tasks.
-    
-    This measure computes standard accuracy but is explicitly marked
-    as compatible with spatial task types.
+
+    This measure computes standard accuracy with `sklearn.metrics.accuracy_score`
+    and marks it as compatible with spatial tasks.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from mlpy.measures.spatial import MeasureSpatialAccuracy
+    >>> y_true = np.array([0, 0, 1, 1])
+    >>> y_pred = np.array([0, 1, 1, 1])
+    >>> MeasureSpatialAccuracy().score(y_true, y_pred)
+    0.75
     """
     
     def __init__(self):
@@ -41,7 +50,25 @@ class MeasureSpatialAccuracy(MeasureClassif):
 
 
 class MeasureSpatialAUC(MeasureClassif):
-    """Area Under ROC Curve for spatial classification tasks."""
+    """Area Under the ROC Curve (AUC) for spatial classification.
+
+    Uses ``sklearn.metrics.roc_auc_score``. For binary problems, expects
+    probabilities for the positive class; for multiclass, computes weighted
+    one-vs-rest AUC.
+
+    Examples
+    --------
+    Binary (non-perfect AUC):
+
+    >>> import numpy as np, pandas as pd
+    >>> from mlpy.measures.spatial import MeasureSpatialAUC
+    >>> from mlpy.predictions import PredictionClassif
+    >>> y_true = np.array([0, 0, 1, 1])
+    >>> prob = pd.DataFrame({0: [0.9, 0.3, 0.4, 0.1], 1: [0.1, 0.7, 0.6, 0.9]})
+    >>> pred = PredictionClassif(task=None, learner_id='demo', row_ids=[0,1,2,3], truth=y_true, prob=prob)
+    >>> round(MeasureSpatialAUC().score(pred), 2)
+    0.75
+    """
     
     def __init__(self):
         super().__init__(
@@ -60,7 +87,7 @@ class MeasureSpatialAUC(MeasureClassif):
             
         # Binary classification
         if prediction.prob.shape[1] == 2:
-            return roc_auc_score(prediction.truth, prediction.prob[:, 1])
+            return roc_auc_score(prediction.truth, prediction.prob.iloc[:, 1])
         
         # Multiclass classification
         try:
@@ -75,7 +102,20 @@ class MeasureSpatialAUC(MeasureClassif):
 
 
 class MeasureSpatialF1(MeasureClassif):
-    """F1 Score for spatial classification tasks."""
+    """F1 score for spatial classification.
+
+    Harmonic mean of precision and recall. Uses weighted averaging for
+    multiclass problems.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from mlpy.measures.spatial import MeasureSpatialF1
+    >>> y_true = np.array([0, 0, 1, 1])
+    >>> y_pred = np.array([0, 1, 1, 1])
+    >>> round(MeasureSpatialF1().score(y_true, y_pred), 2)
+    0.8
+    """
     
     def __init__(self):
         super().__init__(
@@ -95,7 +135,20 @@ class MeasureSpatialF1(MeasureClassif):
 
 
 class MeasureSpatialPrecision(MeasureClassif):
-    """Precision for spatial classification tasks."""
+    """Precision for spatial classification.
+
+    Fraction of predicted positives that are correct. Uses weighted averaging
+    for multiclass problems.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from mlpy.measures.spatial import MeasureSpatialPrecision
+    >>> y_true = np.array([0, 0, 1, 1])
+    >>> y_pred = np.array([0, 1, 1, 1])
+    >>> round(MeasureSpatialPrecision().score(y_true, y_pred), 2)
+    0.67
+    """
     
     def __init__(self):
         super().__init__(
@@ -120,7 +173,20 @@ class MeasureSpatialPrecision(MeasureClassif):
 
 
 class MeasureSpatialRecall(MeasureClassif):
-    """Recall for spatial classification tasks."""
+    """Recall for spatial classification.
+
+    Fraction of actual positives that are recovered. Uses weighted averaging
+    for multiclass problems.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from mlpy.measures.spatial import MeasureSpatialRecall
+    >>> y_true = np.array([0, 0, 1, 1])
+    >>> y_pred = np.array([0, 1, 1, 1])
+    >>> MeasureSpatialRecall().score(y_true, y_pred)
+    1.0
+    """
     
     def __init__(self):
         super().__init__(
@@ -145,7 +211,20 @@ class MeasureSpatialRecall(MeasureClassif):
 
 
 class MeasureSpatialMCC(MeasureClassif):
-    """Matthews Correlation Coefficient for spatial classification tasks."""
+    """Matthews correlation coefficient for spatial classification.
+
+    Balanced measure even with class imbalance; ranges from -1 (total
+    disagreement) to 1 (perfect agreement).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from mlpy.measures.spatial import MeasureSpatialMCC
+    >>> y_true = np.array([0, 0, 1, 1])
+    >>> y_pred = np.array([0, 1, 1, 1])
+    >>> round(MeasureSpatialMCC().score(y_true, y_pred), 3)
+    0.577
+    """
     
     def __init__(self):
         super().__init__(

--- a/mlpy/resamplings/bootstrap.py
+++ b/mlpy/resamplings/bootstrap.py
@@ -29,6 +29,26 @@ class ResamplingBootstrap(Resampling):
         Whether to stratify bootstrap samples by target variable.
     seed : int, optional
         Random seed for reproducibility.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskClassif
+    >>> df = pd.DataFrame({'x': list(range(10)), 'y': [0,1]*5})
+    >>> task = TaskClassif(df, target='y')
+    >>> boot = ResamplingBootstrap(iters=2, ratio=0.8, oob=True, seed=42)
+    >>> boot.instantiate(task)
+    <ResamplingBootstrap[instantiated]:bootstrap>
+    >>> [len(boot.train_set(i)) for i in range(2)]
+    [8, 8]
+    >>> all(len(boot.test_set(i)) > 0 for i in range(2))
+    True
+    
+    Notes
+    -----
+    - Bootstrap allows duplicate IDs in the training set.
+    - With ``oob=True``, the test set size varies by iteration and can be empty
+      in rare cases; an emergency small test subset is created in that case.
     """
     
     def __init__(

--- a/mlpy/resamplings/cv.py
+++ b/mlpy/resamplings/cv.py
@@ -11,8 +11,9 @@ from ..tasks import Task
 class ResamplingCV(Resampling):
     """K-fold cross-validation.
     
-    Splits data into k folds, using each fold as test set once.
-    
+    Splits data into k folds, using each fold as test set once
+    while the remaining folds form the train set.
+
     Parameters
     ----------
     folds : int, default=10
@@ -21,6 +22,25 @@ class ResamplingCV(Resampling):
         Whether to stratify folds by target variable (classification only).
     seed : int, optional
         Random seed for reproducibility.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskClassif
+    >>> df = pd.DataFrame({'x': [1,2,3,4,5,6], 'y': [0,1,0,1,0,1]})
+    >>> task = TaskClassif(df, target='y')
+    >>> cv = ResamplingCV(folds=3, stratify=True, seed=1)
+    >>> cv.instantiate(task)
+    <ResamplingCV[instantiated]:cv>
+    >>> cv.iters
+    3
+    >>> sum(len(cv.test_set(i)) for i in range(cv.iters))
+    6
+    
+    Notes
+    -----
+    - ``stratify=True`` requires a single classification target.
+    - Train/test splits are fixed after ``instantiate(task)``.
     """
     
     def __init__(
@@ -117,6 +137,20 @@ class ResamplingLOO(Resampling):
     
     Special case of k-fold CV where k equals the number of samples.
     Each iteration uses a single sample as test set.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskClassif
+    >>> df = pd.DataFrame({'x': [1,2,3,4], 'y': [0,1,0,1]})
+    >>> task = TaskClassif(df, target='y')
+    >>> loo = ResamplingLOO()
+    >>> loo.instantiate(task)
+    <ResamplingLOO[instantiated]:loo>
+    >>> loo.iters
+    4
+    >>> len(loo.test_set(0))
+    1
     """
     
     def __init__(self):
@@ -165,6 +199,18 @@ class ResamplingRepeatedCV(Resampling):
         Whether to stratify folds by target variable.
     seed : int, optional
         Random seed for reproducibility.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks import TaskClassif
+    >>> df = pd.DataFrame({'x': [1,2,3,4,5,6], 'y': [0,1,0,1,0,1]})
+    >>> task = TaskClassif(df, target='y')
+    >>> rcv = ResamplingRepeatedCV(folds=2, repeats=2, seed=7)
+    >>> rcv.instantiate(task)
+    <ResamplingRepeatedCV[instantiated]:repeated_cv>
+    >>> rcv.iters
+    4
     """
     
     def __init__(

--- a/mlpy/resamplings/spatial.py
+++ b/mlpy/resamplings/spatial.py
@@ -61,19 +61,22 @@ class SpatialKFold(SpatialResampling):
         
     Examples
     --------
-    >>> from mlpy.resamplings.spatial import SpatialKFold
+    >>> import pandas as pd
     >>> from mlpy.tasks.spatial import TaskClassifSpatial
-    >>> 
-    >>> # Create spatial task
-    >>> task = TaskClassifSpatial(data, target='class', coordinate_names=['x', 'y'])
-    >>> 
-    >>> # Create spatial k-fold
-    >>> cv = SpatialKFold(n_folds=5)
+    >>> from mlpy.resamplings.spatial import SpatialKFold
+    >>> df = pd.DataFrame({
+    ...     'x': [0, 1, 2, 3, 4, 5],
+    ...     'y': [0, 1, 2, 3, 4, 5],
+    ...     'y_cls': [0, 0, 1, 1, 0, 1]
+    ... })
+    >>> task = TaskClassifSpatial(df, target='y_cls', coordinate_names=['x', 'y'])
+    >>> cv = SpatialKFold(n_folds=3, random_state=0)
     >>> cv.instantiate(task)
-    >>> 
-    >>> # Get first fold
-    >>> train_idx = cv.train_set(0)
-    >>> test_idx = cv.test_set(0)
+    <SpatialKFold[instantiated]:spatial_kfold>
+    >>> cv.iters
+    3
+    >>> sum(len(cv.test_set(i)) for i in range(cv.iters)) == len(df)
+    True
     """
     
     def __init__(
@@ -245,16 +248,20 @@ class SpatialBlockCV(SpatialResampling):
         
     Examples
     --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks.spatial import TaskClassifSpatial
     >>> from mlpy.resamplings.spatial import SpatialBlockCV
-    >>> 
-    >>> # Create spatial block CV with 3x3 grid
-    >>> cv = SpatialBlockCV(n_blocks=(3, 3))
+    >>> df = pd.DataFrame({
+    ...     'x': [0, 1, 2, 3],
+    ...     'y': [0, 1, 2, 3],
+    ...     'y_cls': [0, 1, 0, 1]
+    ... })
+    >>> task = TaskClassifSpatial(df, target='y_cls', coordinate_names=['x', 'y'])
+    >>> cv = SpatialBlockCV(n_blocks=(2, 2))
     >>> cv.instantiate(task)
-    >>> 
-    >>> # Iterate through folds
-    >>> for i in range(cv.iters):
-    ...     train = cv.train_set(i)
-    ...     test = cv.test_set(i)
+    <SpatialBlockCV[instantiated]:spatial_block>
+    >>> cv.iters
+    4
     """
     
     def __init__(
@@ -448,11 +455,20 @@ class SpatialBufferCV(SpatialResampling):
         
     Examples
     --------
+    >>> import pandas as pd
+    >>> from mlpy.tasks.spatial import TaskClassifSpatial
     >>> from mlpy.resamplings.spatial import SpatialBufferCV
-    >>> 
-    >>> # Create buffer CV with 100m buffer
-    >>> cv = SpatialBufferCV(buffer_distance=100, test_size=0.2, n_folds=5)
+    >>> df = pd.DataFrame({
+    ...     'x': [0, 1, 2, 3, 4],
+    ...     'y': [0, 0, 0, 0, 0],
+    ...     'y_cls': [0, 1, 0, 1, 0]
+    ... })
+    >>> task = TaskClassifSpatial(df, target='y_cls', coordinate_names=['x', 'y'])
+    >>> cv = SpatialBufferCV(buffer_distance=0.5, test_size=2, n_folds=2, random_state=0)
     >>> cv.instantiate(task)
+    <SpatialBufferCV[instantiated]:spatial_buffer>
+    >>> all(len(cv.test_set(i)) == 2 for i in range(cv.iters))
+    True
     """
     
     def __init__(

--- a/tests/test_learners_sklearn.py
+++ b/tests/test_learners_sklearn.py
@@ -34,7 +34,11 @@ try:
         LearnerLasso,
         auto_sklearn,
         LearnerGradientBoostingClassifier,
-        LearnerGradientBoostingRegressor
+        LearnerGradientBoostingRegressor,
+        LearnerAdaBoostClassifier,
+        LearnerAdaBoostRegressor,
+        LearnerExtraTreesClassifier,
+        LearnerExtraTreesRegressor
     )
     from mlpy.learners.sklearn.base import LearnerClassifSKLearn, LearnerRegrSKLearn
     _HAS_MLPY_SKLEARN = True
@@ -277,6 +281,36 @@ class TestClassificationWrappers:
         assert isinstance(pred, PredictionClassif)
         assert hasattr(learner.estimator, "estimators_")
 
+    def test_ada_boost(self, sample_task_classif):
+        """Test AdaBoost wrapper"""
+        learner = LearnerAdaBoostClassifier(
+            n_estimators=15,
+            learning_rate=0.2,
+            random_state=42
+        )
+
+        assert learner.id == "adaboost"
+        learner.train(sample_task_classif)
+        pred = learner.predict(sample_task_classif)
+
+        assert isinstance(pred, PredictionClassif)
+        assert hasattr(learner.estimator, "estimators_")
+
+    def test_extra_trees(self, sample_task_classif):
+        """Test ExtraTrees wrapper"""
+        learner = LearnerExtraTreesClassifier(
+            n_estimators=12,
+            max_depth=4,
+            random_state=42
+        )
+
+        assert learner.id == "extra_trees"
+        learner.train(sample_task_classif)
+        pred = learner.predict(sample_task_classif)
+
+        assert isinstance(pred, PredictionClassif)
+        assert hasattr(learner.estimator, "estimators_")
+
 @pytest.mark.skipif(not _HAS_MLPY_SKLEARN, reason="MLPY sklearn wrappers not available")
 @pytest.mark.skipif(not _HAS_SKLEARN, reason="scikit-learn not installed")
 class TestRegressionWrappers:
@@ -325,6 +359,36 @@ class TestRegressionWrappers:
         )
 
         assert learner.id == "gradient_boosting_regr"
+        learner.train(sample_task_regr)
+        pred = learner.predict(sample_task_regr)
+
+        assert isinstance(pred, PredictionRegr)
+        assert hasattr(learner.estimator, "estimators_")
+
+    def test_ada_boost_regression(self, sample_task_regr):
+        """Test AdaBoostRegression wrapper"""
+        learner = LearnerAdaBoostRegressor(
+            n_estimators=15,
+            learning_rate=0.2,
+            random_state=42
+        )
+
+        assert learner.id == "adaboost_regr"
+        learner.train(sample_task_regr)
+        pred = learner.predict(sample_task_regr)
+
+        assert isinstance(pred, PredictionRegr)
+        assert hasattr(learner.estimator, "estimators_")
+
+    def test_extra_trees_regression(self, sample_task_regr):
+        """Test ExtraTreesRegression wrapper"""
+        learner = LearnerExtraTreesRegressor(
+            n_estimators=12,
+            max_depth=4,
+            random_state=42
+        )
+
+        assert learner.id == "extra_trees_regr"
         learner.train(sample_task_regr)
         pred = learner.predict(sample_task_regr)
 

--- a/tests/test_learners_sklearn.py
+++ b/tests/test_learners_sklearn.py
@@ -32,7 +32,9 @@ try:
         LearnerLinearRegression,
         LearnerRidge,
         LearnerLasso,
-        auto_sklearn
+        auto_sklearn,
+        LearnerGradientBoostingClassifier,
+        LearnerGradientBoostingRegressor
     )
     from mlpy.learners.sklearn.base import LearnerClassifSKLearn, LearnerRegrSKLearn
     _HAS_MLPY_SKLEARN = True
@@ -260,6 +262,20 @@ class TestClassificationWrappers:
         assert pred.prob is not None
         assert hasattr(learner.estimator, 'estimators_')
 
+    def test_gradient_boosting(self, sample_task_classif):
+        """Test GradientBoosting wrapper"""
+        learner = LearnerGradientBoostingClassifier(
+            n_estimators=20,
+            learning_rate=0.1,
+            random_state=42
+        )
+
+        assert learner.id == "gradient_boosting"
+        learner.train(sample_task_classif)
+        pred = learner.predict(sample_task_classif)
+
+        assert isinstance(pred, PredictionClassif)
+        assert hasattr(learner.estimator, "estimators_")
 
 @pytest.mark.skipif(not _HAS_MLPY_SKLEARN, reason="MLPY sklearn wrappers not available")
 @pytest.mark.skipif(not _HAS_SKLEARN, reason="scikit-learn not installed")
@@ -300,6 +316,20 @@ class TestRegressionWrappers:
         # Check that Lasso performs feature selection (some coefs should be 0)
         assert np.any(np.abs(learner.estimator.coef_) < 1e-10)
 
+    def test_gradient_boosting_regression(self, sample_task_regr):
+        """Test GradientBoostingRegression wrapper"""
+        learner = LearnerGradientBoostingRegressor(
+            n_estimators=20,
+            learning_rate=0.1,
+            random_state=42
+        )
+
+        assert learner.id == "gradient_boosting_regr"
+        learner.train(sample_task_regr)
+        pred = learner.predict(sample_task_regr)
+
+        assert isinstance(pred, PredictionRegr)
+        assert hasattr(learner.estimator, "estimators_")
 
 @pytest.mark.skipif(not _HAS_MLPY_SKLEARN, reason="MLPY sklearn wrappers not available")
 class TestAutoWrap:


### PR DESCRIPTION
Standardizes docstrings to numpydoc style across sklearn learners wrappers, measures and resampling:
mlpy/learners/sklearn/classification.py
mlpy/learners/sklearn/regression.py
mlpy/measures/classification.py
mlpy/measures/regression.py
mlpy/measures/spatial.py
(resamplings only needed to fix doctests)
mlpy/resamplings/cv.py
mlpy/resamplings/bootstrap.py
mlpy/resampling/spatial.py

in "MeasureSpatialAuc" (mlpy/measures/spatial.py), fixed probability column selection using .iloc to avoid InvalidIndexError.

before: return roc_auc_score(prediction.truth, prediction.prob[:, 1])
after: return roc_auc_score(prediction.truth, prediction.prob.iloc[:, 1])